### PR TITLE
Remove unused net_reduce2 property

### DIFF
--- a/optlam.js
+++ b/optlam.js
@@ -442,5 +442,6 @@ module.exports = (function(){
         net_reduce      : net_reduce,
         stats           : stats,
         
-        net_reduce_2    : net_reduce_2};
+        // net_reduce_2    : net_reduce_2
+    };
 })();


### PR DESCRIPTION
Fix for "net_reduce_2 is not defined" error on line 445. Looks like this was leftover code.
